### PR TITLE
add react-native 0.18.0-rc as PeerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/oblador/react-native-lightbox",
   "peerDependencies": {
-    "react-native": ">=0.11.0 || 0.11.0-rc || 0.12.0-rc || 0.13.0-rc"
+    "react-native": ">=0.11.0 || 0.11.0-rc || 0.12.0-rc || 0.13.0-rc || 0.18.0-rc"
   },
   "dependencies": {
     "react-timer-mixin": "^0.13.3"


### PR DESCRIPTION
I tested on React Native 0.18.0-rc and everything is fine. Can you please add this version to PeerDependencies? Thanks