### PR TITLE
setState before component is unmounted

### DIFF
--- a/LightboxOverlay.js
+++ b/LightboxOverlay.js
@@ -137,10 +137,10 @@ var LightboxOverlay = React.createClass({
       this.state.openVal,
       { toValue: 0, ...this.props.springConfig }
     ).start(() => {
-      this.props.onClose();
       this.setState({
         isAnimating: false,
       });
+      this.props.onClose();
     });
   },
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/oblador/react-native-lightbox",
   "peerDependencies": {
-    "react-native": ">=0.11.0 || 0.11.0-rc || 0.12.0-rc || 0.13.0-rc"
+    "react-native": ">=0.11.0 || 0.11.0-rc || 0.12.0-rc || 0.13.0-rc || 0.18.0-rc"
   },
   "dependencies": {
     "react-timer-mixin": "^0.13.3"


### PR DESCRIPTION
When it close the lightbox , there will be a warning, "Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the LightboxOverlay component."

Because the onClose() will unmount the component, and the setState() will be illegal. 

By switching two of them, you will get no warning.