### PR TITLE
Add View component as child of TouchableHighlight

### DIFF
--- a/Lightbox.js
+++ b/Lightbox.js
@@ -141,7 +141,9 @@ var Lightbox = React.createClass({
             underlayColor={this.props.underlayColor}
             onPress={this.open}
           >
-            {this.props.children}
+            <View>
+              {this.props.children}
+            </View>
           </TouchableHighlight>
         </Animated.View>
         {this.props.navigator ? false : <LightboxOverlay {...this.getOverlayProps()} />}


### PR DESCRIPTION
Otherwise React Native (0.18 at least) is complaining:

"Touchable child must either be native or forward setNativeProps to native component"

![simulator screen shot 05 02 2016 14 14 15](https://cloud.githubusercontent.com/assets/410305/12847381/2ad13b0c-cc13-11e5-9abd-8d87a90f2888.png)
