### PR TITLE
Allow non-native React component children

### DIFF
--- a/Lightbox.js
+++ b/Lightbox.js
@@ -141,7 +141,9 @@ var Lightbox = React.createClass({
             underlayColor={this.props.underlayColor}
             onPress={this.open}
           >
-            {this.props.children}
+            <View style={{flex: 1}}>
+              {this.props.children}
+            </View>
           </TouchableHighlight>
         </Animated.View>
         {this.props.navigator ? false : <LightboxOverlay {...this.getOverlayProps()} />}


### PR DESCRIPTION
There is a [check](https://github.com/facebook/react-native/blob/4b98511a3e10bf1fe4ddc210d393849bfe608c47/Libraries/Components/Touchable/ensureComponentIsNative.js#L16) on child elements of TouchableHighlight that requires the children to be native components. In order to allow for non-native children, I've added a view wrapper.

I am wondering if you might consider making this change to support custom React components as children of the Lightbox component.

UPDATE: Only TouchableHighlight has this check.