### PR TITLE
Fix deprecated warning of StatusBarIOS

### DIFF
--- a/LightboxOverlay.js
+++ b/LightboxOverlay.js
@@ -13,7 +13,7 @@ var {
   Dimensions,
   PanResponder,
   TouchableOpacity,
-  StatusBarIOS,
+  StatusBar,
   Modal,
   Platform,
 } = React;
@@ -107,9 +107,7 @@ var LightboxOverlay = React.createClass({
   },
 
   open: function() {
-    if(StatusBarIOS) {
-      StatusBarIOS.setHidden(true, 'fade');
-    }
+    StatusBar.setHidden(true, 'fade');
     this.state.pan.setValue(0);
     this.setState({
       isAnimating: true,
@@ -127,9 +125,7 @@ var LightboxOverlay = React.createClass({
   },
 
   close: function() {
-    if(StatusBarIOS) {
-      StatusBarIOS.setHidden(false, 'fade');
-    }
+    StatusBar.setHidden(false, 'fade');
     this.setState({
       isAnimating: true,
     });


### PR DESCRIPTION
`StatusBarIOS.setHidden` is deprecated since react-native v0.22.
Use StatusBar instead of StatusBarIOS.