### PR TITLE
Screen rotation issue

### DIFF
--- a/LightboxOverlay.js
+++ b/LightboxOverlay.js
@@ -215,7 +215,7 @@ var LightboxOverlay = React.createClass({
     );
     if(this.props.navigator) {
       return (
-        <View onLayout={() => {this.recalculateDimensions();}}>
+        <View onLayout={() => {this.recalculateDimensions()}}>
           {background}
           {content}
           {header}
@@ -223,11 +223,13 @@ var LightboxOverlay = React.createClass({
       );
     }
     return (
-      <Modal visible={isOpen} transparent={true} onLayout={() => {this.recalculateDimensions();}} >
-        {background}
-        {content}
-        {header}
-      </Modal>
+      <View onLayout={() => {this.recalculateDimensions()}}>
+        <Modal visible={isOpen} transparent={true}>
+          {background}
+          {content}
+          {header}
+        </Modal>
+      </View>
     );
   }
 });


### PR DESCRIPTION
Currently, if you rotate your screen, the lightbox maintains the original orientation dimensions resulting in a portrait image being rendered on a landscape screen (and vice versa).  This is because the window dimensions are set when the component loads.  
My changes pull the dimensions into the component state and re-evaluate them when the orientation changes.  I've attached some gifs to demonstrate the 'before' and 'after'.

Before:
![before](https://cloud.githubusercontent.com/assets/733873/15899793/f16ccd9a-2d6a-11e6-917b-926a87bd978a.gif)

After:
![after](https://cloud.githubusercontent.com/assets/733873/15899806/f8018b28-2d6a-11e6-9c8d-d938b83f23ad.gif)

FWIW, this doesn't seem to have any effect on Android. On my Android simulator, the image just closes when you rotate the screen.
