### PR TITLE
Allow custom rendering of the LightboxOverlay (for better NavigationExperimental support)

### DIFF
--- a/Lightbox.js
+++ b/Lightbox.js
@@ -35,6 +35,8 @@ var Lightbox = React.createClass({
     }),
     swipeToDismiss:  PropTypes.bool,
     hideStatusBar:   PropTypes.bool,
+    showOverlay:     PropTypes.func,
+    hideOverlay:     PropTypes.func,
   },
 
   getDefaultProps: function() {
@@ -82,7 +84,12 @@ var Lightbox = React.createClass({
       backgroundColor: this.props.backgroundColor,
       children: this.getContent(),
       onClose: this.onClose,
+      useModal: this._useModal(),
     };
+  },
+
+  _useModal() {
+    return !this.navigator && !this.props.showOverlay;
   },
 
   open: function() {
@@ -90,7 +97,7 @@ var Lightbox = React.createClass({
       this.props.onOpen();
 
       this.setState({
-        isOpen: (this.props.navigator ? true : false),
+        isOpen: !this._useModal(),
         isAnimating: true,
         origin: {
           width,
@@ -99,7 +106,9 @@ var Lightbox = React.createClass({
           y: py,
         },
       }, () => {
-        if(this.props.navigator) {
+        if (this.props.showOverlay) {
+          this.props.showOverlay(LightboxOverlay, this.getOverlayProps());
+        } else if (this.props.navigator) {
           var route = {
             component: LightboxOverlay,
             passProps: this.getOverlayProps(),
@@ -128,7 +137,9 @@ var Lightbox = React.createClass({
     this.setState({
       isOpen: false,
     }, this.props.onClose);
-    if(this.props.navigator) {
+    if (this.props.hideOverlay) {
+      this.props.hideOverlay();
+    } else if (this.props.navigator) {
       var routes = this.props.navigator.getCurrentRoutes();
       routes.pop();
       this.props.navigator.immediatelyResetRouteStack(routes);
@@ -151,7 +162,7 @@ var Lightbox = React.createClass({
             {this.props.children}
           </TouchableHighlight>
         </Animated.View>
-        {this.props.navigator ? false : <LightboxOverlay {...this.getOverlayProps()} />}
+        {this._useModal() && <LightboxOverlay {...this.getOverlayProps()} />}
       </View>
     );
   }

--- a/Lightbox.js
+++ b/Lightbox.js
@@ -34,11 +34,13 @@ var Lightbox = React.createClass({
       friction:      PropTypes.number,
     }),
     swipeToDismiss:  PropTypes.bool,
+    hideStatusBar:   PropTypes.bool,
   },
 
   getDefaultProps: function() {
     return {
       swipeToDismiss: true,
+      hideStatusBar: true,
       onOpen: () => {},
       onClose: () => {},
     };
@@ -75,6 +77,7 @@ var Lightbox = React.createClass({
       origin: this.state.origin,
       renderHeader: this.props.renderHeader,
       swipeToDismiss: this.props.swipeToDismiss,
+      hideStatusBar: this.props.hideStatusBar,
       springConfig: this.props.springConfig,
       backgroundColor: this.props.backgroundColor,
       children: this.getContent(),

--- a/LightboxOverlay.js
+++ b/LightboxOverlay.js
@@ -46,6 +46,11 @@ var LightboxOverlay = React.createClass({
   },
 
   getInitialState: function() {
+
+    if (!this.props.hideStatusBar) {
+      STATUS_BAR_OFFSET = 0;
+    }
+      
     return {
       isAnimating: false,
       isPanning: false,
@@ -219,7 +224,7 @@ var LightboxOverlay = React.createClass({
       );
     }
     return (
-      <Modal visible={isOpen} transparent={true} onRequestClose={() => {}}>
+      <Modal visible={isOpen} transparent={true} onRequestClose={() =>{}}>
         {background}
         {content}
         {header}

--- a/LightboxOverlay.js
+++ b/LightboxOverlay.js
@@ -50,7 +50,7 @@ var LightboxOverlay = React.createClass({
     if (!this.props.hideStatusBar) {
       STATUS_BAR_OFFSET = 0;
     }
-      
+
     return {
       isAnimating: false,
       isPanning: false,
@@ -214,7 +214,7 @@ var LightboxOverlay = React.createClass({
         {this.props.children}
       </Animated.View>
     );
-    if(this.props.navigator) {
+    if(!this.props.useModal) {
       return (
         <View>
           {background}

--- a/LightboxOverlay.js
+++ b/LightboxOverlay.js
@@ -111,7 +111,9 @@ var LightboxOverlay = React.createClass({
   },
 
   open: function() {
-    StatusBar.setHidden(true, 'fade');
+    if (this.props.hideStatusBar) {
+      StatusBar.setHidden(true, 'fade');
+    }
     this.state.pan.setValue(0);
     this.setState({
       isAnimating: true,
@@ -129,7 +131,9 @@ var LightboxOverlay = React.createClass({
   },
 
   close: function() {
-    StatusBar.setHidden(false, 'fade');
+    if (this.props.hideStatusBar) {
+      StatusBar.setHidden(false, 'fade');
+    }
     this.setState({
       isAnimating: true,
     });
@@ -215,7 +219,7 @@ var LightboxOverlay = React.createClass({
       );
     }
     return (
-      <Modal visible={isOpen} transparent={true}>
+      <Modal visible={isOpen} transparent={true} onRequestClose={() => {}}>
         {background}
         {content}
         {header}


### PR DESCRIPTION
This PR piggybacks on @jreziga's PR here: https://github.com/oblador/react-native-lightbox/pull/51 and also adds the ability for clients to do custom rendering of the overlay.

Right now the lightbox has two methods of rendering: `Navigator` and
`Modal`.

Sometimes neither of these options work well. For example, if a client
is using `NavigationExperimental` and doesn't want to use a modal, they
are stuck.

This change allows clients to have full control over rending the
Overlay.

`showOverlay` is a callback that accepts the `LightboxOverlay` component
and associated props and clients can render the component however they
want.

`hideOverlay` is a callback so clients can specify how to hide the
overlay in a custom fashion.