### PR TITLE
renderContent can use activeProps variable

### DIFF
--- a/Lightbox.js
+++ b/Lightbox.js
@@ -58,7 +58,9 @@ var Lightbox = React.createClass({
   },
 
   getContent: function() {
-    if(this.props.renderContent) {
+    if((this.props.renderContent) && (this.props.activeProps)) {
+      return this.props.renderContent(this.props.activeProps);
+    } else if(this.props.renderContent) {
       return this.props.renderContent();
     } else if(this.props.activeProps) {
       return cloneElement(


### PR DESCRIPTION
Previously, there was no way how to simply pass arguments from <Lightbox> to
the renderContent(). The only possibility was to create a new component and
utilize activeProps what works fine for simpler cases. But this component has
to be either native or it have to forward setNativeProps. Such forwarding
may be a little more complex as shown at
https://github.com/facebook/react-native/issues/1040
where change of application logic was the solution. Such solution does not
make sense with <Lightbox>.