### PR TITLE
fix: No suitable image URL loader found for (null)

### DIFF
--- a/ZoomableImage.js
+++ b/ZoomableImage.js
@@ -36,7 +36,7 @@ var ZoomableImage = React.createClass({
   },
 
   componentDidMount: function() {
-    if(Image.getSize && this.props.source) {
+    if(Image.getSize && this.props.source.uri) {
       Image.getSize(this.props.source.uri,
         (width, height) => {
           this.setState({width, height});


### PR DESCRIPTION
when source is ```require('../images/look.jpg')```