### PR TITLE
Add didOpen/willClose

### DIFF
--- a/Lightbox.js
+++ b/Lightbox.js
@@ -11,7 +11,9 @@ export default class Lightbox extends Component {
     renderContent:   PropTypes.func,
     underlayColor:   PropTypes.string,
     backgroundColor: PropTypes.string,
+    didOpen:         PropTypes.func,
     onOpen:          PropTypes.func,
+    willClose:       PropTypes.func,
     onClose:         PropTypes.func,
     springConfig:    PropTypes.shape({
       tension:       PropTypes.number,
@@ -23,6 +25,8 @@ export default class Lightbox extends Component {
   static defaultProps = {
     swipeToDismiss: true,
     onOpen: () => {},
+    didOpen: () => {},
+    willClose: () => {},
     onClose: () => {},
   };
 
@@ -57,6 +61,8 @@ export default class Lightbox extends Component {
     springConfig: this.props.springConfig,
     backgroundColor: this.props.backgroundColor,
     children: this.getContent(),
+    didOpen: this.props.didOpen,
+    willClose: this.props.willClose,
     onClose: this.onClose,
   })
 
@@ -74,6 +80,7 @@ export default class Lightbox extends Component {
           y: py,
         },
       }, () => {
+        this.props.didOpen();
         if(this.props.navigator) {
           const route = {
             component: LightboxOverlay,

--- a/LightboxOverlay.js
+++ b/LightboxOverlay.js
@@ -63,6 +63,7 @@ export default class LightboxOverlay extends Component {
     renderHeader:    PropTypes.func,
     onOpen:          PropTypes.func,
     onClose:         PropTypes.func,
+    willClose:         PropTypes.func,
     swipeToDismiss:  PropTypes.bool,
   };
 
@@ -144,10 +145,14 @@ export default class LightboxOverlay extends Component {
     Animated.spring(
       this.state.openVal,
       { toValue: 1, ...this.props.springConfig }
-    ).start(() => this.setState({ isAnimating: false }));
+    ).start(() => {
+      this.setState({ isAnimating: false });
+      this.props.didOpen();
+    });
   }
 
   close = () => {
+    this.props.willClose();
     if(isIOS) {
       StatusBar.setHidden(false, 'fade');
     }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ const LightboxView ({ navigator }) => (
 
 ### Navigator setup/Android support
 
-For android support you must pass a reference to a `Navigator` since it does not yet have the `Modal` component and is not on the official todo list. See the `Example` project for a complete example. 
+For android support you must pass a reference to a `Navigator` since it does not yet have the `Modal` component and is not on the official todo list. See the `Example` project for a complete example.
 
 ```js
 const renderScene = (route, navigator) => {
@@ -55,8 +55,10 @@ const MyApp = () => (
 |**`activeProps`**|`object`|Optional set of props applied to the content component when in lightbox mode. Usable for applying custom styles or higher resolution image source.|
 |**`renderHeader(close)`**|`function`|Custom header instead of default with X button|
 |**`renderContent`**|`function`|Custom lightbox content instead of default child content|
+|**`willClose`**|`function`|Triggered before lightbox is closed|
 |**`onClose`**|`function`|Triggered when lightbox is closed|
 |**`onOpen`**|`function`|Triggered when lightbox is opened|
+|**`didOpen`**|`function`|Triggered after lightbox is opened|
 |**`underlayColor`**|`string`|Color of touchable background, defaults to `black`|
 |**`backgroundColor`**|`string`|Color of lightbox background, defaults to `black`|
 |**`swipeToDismiss`**|`bool`|Enables gestures to dismiss the fullscreen mode by swiping up or down, defaults to `true`.|
@@ -66,9 +68,9 @@ const MyApp = () => (
 
 ![Demo](https://cloud.githubusercontent.com/assets/378279/9074360/16eac5d6-3b09-11e5-90af-a69980e9f4be.gif)
 
-## Example 
+## Example
 
-Check full example in the `Example` folder. 
+Check full example in the `Example` folder.
 
 ## License
 


### PR DESCRIPTION
In my app I wanted to remove some UI before the lightbox was closed, but onClose fires after the animation is done. So I added a couple of hooks for `didOpen` and `willClose`.

Ideally I'd rather have all the callbacks named consistently - willOpen / onOpen, willClose / onClose - but they're currently named inconsistently - onOpen fires before the event and onClose fires afterwards. 