### PR TITLE
Added the ability to specify opening and closing animation props

### DIFF
--- a/Lightbox.js
+++ b/Lightbox.js
@@ -7,6 +7,8 @@ import LightboxOverlay from './LightboxOverlay';
 export default class Lightbox extends Component {
   static propTypes = {
     activeProps:     PropTypes.object,
+    openingProps:     PropTypes.object,
+    closingProps:     PropTypes.object,
     renderHeader:    PropTypes.func,
     renderContent:   PropTypes.func,
     underlayColor:   PropTypes.string,
@@ -44,18 +46,16 @@ export default class Lightbox extends Component {
   getContent = () => {
     if(this.props.renderContent) {
       return this.props.renderContent();
-    } else if(this.props.activeProps) {
-      return cloneElement(
-        Children.only(this.props.children),
-        this.props.activeProps
-      );
-    }
+    } 
     return this.props.children;
   }
 
   getOverlayProps = () => ({
     isOpen: this.state.isOpen,
     origin: this.state.origin,
+    activeProps: this.props.activeProps,
+    openingProps: this.props.openingProps,
+    closingProps: this.props.closingProps,
     renderHeader: this.props.renderHeader,
     swipeToDismiss: this.props.swipeToDismiss,
     springConfig: this.props.springConfig,

--- a/LightboxOverlay.js
+++ b/LightboxOverlay.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Children, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import { Animated, Dimensions, Modal, PanResponder, Platform, StatusBar, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
@@ -135,6 +135,7 @@ export default class LightboxOverlay extends Component {
     this.state.pan.setValue(0);
     this.setState({
       isAnimating: true,
+      isOpening: true,
       target: {
         x: 0,
         y: 0,
@@ -146,7 +147,10 @@ export default class LightboxOverlay extends Component {
       this.state.openVal,
       { toValue: 1, ...this.props.springConfig }
     ).start(() => {
-      this.setState({ isAnimating: false });
+      this.setState({ 
+        isAnimating: false, 
+        isOpening: false
+      });
       this.props.didOpen();
     });
   }
@@ -158,6 +162,7 @@ export default class LightboxOverlay extends Component {
     }
     this.setState({
       isAnimating: true,
+      isClosing: true,
     });
     Animated.spring(
       this.state.openVal,
@@ -165,6 +170,7 @@ export default class LightboxOverlay extends Component {
     ).start(() => {
       this.setState({
         isAnimating: false,
+        isClosing: false,
       });
       this.props.onClose();
     });
@@ -174,6 +180,19 @@ export default class LightboxOverlay extends Component {
     if(this.props.isOpen != props.isOpen && props.isOpen) {
       this.open();
     }
+  }
+
+  getContent = () => {
+    if (this.state.isOpening && this.props.openingProps) {
+      return cloneElement(Children.only(this.props.children), this.props.openingProps)
+    }
+    else if (this.state.isClosing && this.props.closingProps) {
+      return cloneElement(Children.only(this.props.children), this.props.closingProps)
+    }
+    else if (this.props.activeProps) {
+      return cloneElement(Children.only(this.props.children), this.props.activeProps)
+    }
+    return this.props.children
   }
 
   render() {
@@ -227,7 +246,7 @@ export default class LightboxOverlay extends Component {
     )}</Animated.View>);
     const content = (
       <Animated.View style={[openStyle, dragStyle]} {...handlers}>
-        {this.props.children}
+        {this.getContent()}
       </Animated.View>
     );
 


### PR DESCRIPTION
My specific use case is that the image in my Lightbox uses `resizeMode='cover'` while not active and `resizeMode='contain'` while active -- so basically it's cropped while in a list and not cropped while open. 

During the closing animation, it would keep the `contain` prop until the animation was finished. This resulted in black bars around the image until the end of the animation and then it would instantly pop to the `cover` prop which looked terrible. 

I found that by setting the `cover` prop before the close animation starts, everything works great. 

I'm unsure if this was the best way to accomplish this so I'm open to any feedback anyone has.