### PR TITLE
[Android] Fix jumpy animation

### DIFF
--- a/LightboxOverlay.js
+++ b/LightboxOverlay.js
@@ -5,7 +5,6 @@ import { Animated, Dimensions, Modal, PanResponder, Platform, StatusBar, StyleSh
 const WINDOW_HEIGHT = Dimensions.get('window').height;
 const WINDOW_WIDTH = Dimensions.get('window').width;
 const DRAG_DISMISS_THRESHOLD = 150;
-const STATUS_BAR_OFFSET = (Platform.OS === 'android' ? -25 : 0);
 const isIOS = Platform.OS === 'ios';
 
 const styles = StyleSheet.create({
@@ -211,7 +210,7 @@ export default class LightboxOverlay extends Component {
 
     const openStyle = [styles.open, {
       left:   openVal.interpolate({inputRange: [0, 1], outputRange: [origin.x, target.x]}),
-      top:    openVal.interpolate({inputRange: [0, 1], outputRange: [origin.y + STATUS_BAR_OFFSET, target.y + STATUS_BAR_OFFSET]}),
+      top:    openVal.interpolate({inputRange: [0, 1], outputRange: [origin.y, target.y]}),
       width:  openVal.interpolate({inputRange: [0, 1], outputRange: [origin.width, WINDOW_WIDTH]}),
       height: openVal.interpolate({inputRange: [0, 1], outputRange: [origin.height, WINDOW_HEIGHT]}),
     }];


### PR DESCRIPTION
### Description
The `y` coordinate sent by the React Native `measure` seems to take the StatusBar height into account. There is no need to do the subtraction anymore.

### Steps to reproduce
- Run the Example on an Android device
- Touch the pig with the hat
  - Before the beginning of the opening animation, the image moves suddenly few pixels upward (very fast, hard to see)
  - When the lightbox is open, touch/untouch the image makes it jump vertically of few pixels too
  - At the end of the closing animation, the image moves suddendly few pixels downward to fit in its container again.

With that fix, the 3 issues disappear.

CC my teammate @philtrep