### PR TITLE
Use Component.propTypes instead of static propTypes

### DIFF
--- a/Lightbox.js
+++ b/Lightbox.js
@@ -5,31 +5,6 @@ import { Animated, TouchableHighlight, View } from 'react-native';
 import LightboxOverlay from './LightboxOverlay';
 
 export default class Lightbox extends Component {
-  static propTypes = {
-    activeProps:     PropTypes.object,
-    renderHeader:    PropTypes.func,
-    renderContent:   PropTypes.func,
-    underlayColor:   PropTypes.string,
-    backgroundColor: PropTypes.string,
-    didOpen:         PropTypes.func,
-    onOpen:          PropTypes.func,
-    willClose:       PropTypes.func,
-    onClose:         PropTypes.func,
-    springConfig:    PropTypes.shape({
-      tension:       PropTypes.number,
-      friction:      PropTypes.number,
-    }),
-    swipeToDismiss:  PropTypes.bool,
-  };
-
-  static defaultProps = {
-    swipeToDismiss: true,
-    onOpen: () => {},
-    didOpen: () => {},
-    willClose: () => {},
-    onClose: () => {},
-  };
-
   state = {
     isOpen: false,
     origin: {
@@ -138,3 +113,32 @@ export default class Lightbox extends Component {
     );
   }
 }
+
+Lightbox.propTypes = {
+  activeProps: PropTypes.object,
+  renderHeader: PropTypes.func,
+  renderContent: PropTypes.func,
+  underlayColor: PropTypes.string,
+  backgroundColor: PropTypes.string,
+  didOpen: PropTypes.func,
+  onOpen: PropTypes.func,
+  willClose: PropTypes.func,
+  onClose: PropTypes.func,
+  springConfig: PropTypes.shape({
+    tension: PropTypes.number,
+    friction: PropTypes.number,
+  }),
+  swipeToDismiss: PropTypes.bool,
+};
+
+Lightbox.defaultProps = {
+  swipeToDismiss: true,
+  onOpen: () => {
+  },
+  didOpen: () => {
+  },
+  willClose: () => {
+  },
+  onClose: () => {
+  },
+};


### PR DESCRIPTION
A simple enhancement, as the title suggests. Using `Component.propTypes` will make it easier for developers who use IDEs to view the list of props that the component has, and see suggestions for prop names as he types. Also, in case any prop was made `isRequired`, a warning will be shown to the developer to `insert required attribute...` by the inspector.