### PR TITLE
Fix: Header getting cropped in ios

### DIFF
--- a/LightboxOverlay.js
+++ b/LightboxOverlay.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Animated, Dimensions, Modal, PanResponder, Platform, StatusBar, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Animated, Dimensions, Modal, PanResponder, Platform, StatusBar, SafeAreaView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 const WINDOW_HEIGHT = Dimensions.get('window').height;
 const WINDOW_WIDTH = Dimensions.get('window').width;
@@ -220,9 +220,11 @@ export default class LightboxOverlay extends Component {
     const header = (<Animated.View style={[styles.header, lightboxOpacityStyle]}>{(renderHeader ?
       renderHeader(this.close) :
       (
-        <TouchableOpacity onPress={this.close}>
-          <Text style={styles.closeButton}>×</Text>
-        </TouchableOpacity>
+        <SafeAreaView>
+          <TouchableOpacity onPress={this.close}>
+            <Text style={styles.closeButton}>×</Text>
+          </TouchableOpacity>
+        </SafeAreaView>
       )
     )}</Animated.View>);
     const content = (


### PR DESCRIPTION
Added SafeAreaView as a wrapper around header

**Before**
<img width="417" alt="Screenshot 2021-09-02 at 5 23 48 PM" src="https://user-images.githubusercontent.com/32446002/131839059-731e4d7f-2b99-4411-b7f3-97544d0f63e9.png">

**After**
<img width="417" alt="Screenshot 2021-09-02 at 5 24 32 PM" src="https://user-images.githubusercontent.com/32446002/131839157-dc62bc57-4067-4bf8-b697-06b611dd1d08.png">
