### PR TITLE
[FIXED] onPanResponderMove is not a funciton issue and added the second necessary argument {useNativeDriver:true} option on Animated.event function

### DIFF
--- a/LightboxOverlay.js
+++ b/LightboxOverlay.js
@@ -96,10 +96,11 @@ export default class LightboxOverlay extends Component {
         this.state.pan.setValue(0);
         this.setState({ isPanning: true });
       },
-      onPanResponderMove: Animated.event([
+      onPanResponderMove:()=> Animated.event([
         null,
         { dy: this.state.pan }
-      ]),
+       
+      ],{useNativeDriver:true}),
       onPanResponderTerminationRequest: (evt, gestureState) => true,
       onPanResponderRelease: (evt, gestureState) => {
         if(Math.abs(gestureState.dy) > DRAG_DISMISS_THRESHOLD) {


### PR DESCRIPTION
1. Fixed the onPandResponderMove is not a function issue.
2. Fixed the Animated.event requires a second argument issue.